### PR TITLE
[FileMethodCountCheck] Fix errors when building using Maven

### DIFF
--- a/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/FileMethodCountCheck.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/magik/checks/checks/FileMethodCountCheck.java
@@ -1,13 +1,11 @@
 package nl.ramsolutions.sw.magik.checks.checks;
 
 import com.sonar.sslr.api.AstNode;
-
-import org.sonar.check.Rule;
-import org.sonar.check.RuleProperty;
-
 import nl.ramsolutions.sw.magik.api.MagikGrammar;
 import nl.ramsolutions.sw.magik.checks.DisabledByDefault;
 import nl.ramsolutions.sw.magik.checks.MagikCheck;
+import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
 
 /**
  * Check if file contains too many methods.

--- a/magik-checks/src/test/java/nl/ramsolutions/sw/magik/checks/checks/FileMethodCountCheckTest.java
+++ b/magik-checks/src/test/java/nl/ramsolutions/sw/magik/checks/checks/FileMethodCountCheckTest.java
@@ -11,6 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class FileMethodCountCheckTest extends MagikCheckTestBase {
 
+    @SuppressWarnings("checkstyle:JavadocVariable")
+    public static final int MAX_METHOD_COUNT = 10;
+
     @Test
     void testTooManyMethods() {
         final FileMethodCountCheck check = new FileMethodCountCheck();
@@ -26,7 +29,7 @@ public class FileMethodCountCheckTest extends MagikCheckTestBase {
     @Test
     void testOk() {
         final FileMethodCountCheck check = new FileMethodCountCheck();
-        check.maxMethodCount = 10;
+        check.maxMethodCount = MAX_METHOD_COUNT;
         final String code = ""
             + "_method a.m1 _endmethod\n"
             + "_method a.m1 _endmethod\n"


### PR DESCRIPTION
Fix the next four errors:
```
[ERROR] src\main\java\nl\ramsolutions\sw\magik\checks\checks\FileMethodCountCheck.java:[5,1] (imports) ImportOrder: Extra separation in import group before 'org.sonar.check.Rule'
[ERROR] src\main\java\nl\ramsolutions\sw\magik\checks\checks\FileMethodCountCheck.java:[8,1] (imports) ImportOrder: Extra separation in import group before 'nl.ramsolutions.sw.magik.api.MagikGrammar'
[ERROR] src\main\java\nl\ramsolutions\sw\magik\checks\checks\FileMethodCountCheck.java:[8,1] (imports) ImportOrder: Wrong order for 'nl.ramsolutions.sw.magik.api.MagikGrammar' import.
[ERROR] src\test\java\nl\ramsolutions\sw\magik\checks\checks\FileMethodCountCheckTest.java:[29,32] (coding) MagicNumber: '10' is a magic number.
```