### PR TITLE
Bump google-java-format and cleanthat

### DIFF
--- a/changes/618.misc.md
+++ b/changes/618.misc.md
@@ -1,0 +1,1 @@
+Bump `cleanthat` and `google-java-format` versions manually, since Dependabot can't see them (they're only referenced from spotless-maven-plugin's own `<configuration>` block, not a real `<dependency>`/`<plugin>` position).

--- a/magik-checks/src/main/java/nl/ramsolutions/sw/checks/Check.java
+++ b/magik-checks/src/main/java/nl/ramsolutions/sw/checks/Check.java
@@ -7,12 +7,12 @@ import nl.ramsolutions.sw.OpenedFile;
 /** Base for Magik/module.def/product.def code checks. */
 public interface Check {
 
-  public List<Issue> scanFileForIssues(final OpenedFile openedFile);
+  List<Issue> scanFileForIssues(final OpenedFile openedFile);
 
-  public void setHolder(final CheckHolder holder);
+  void setHolder(final CheckHolder holder);
 
   @CheckForNull
-  public CheckHolder getHolder();
+  CheckHolder getHolder();
 
-  public void setParameter(final String name, final Object value) throws IllegalAccessException;
+  void setParameter(final String name, final Object value) throws IllegalAccessException;
 }

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/ITypeStringDefinition.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/definitions/ITypeStringDefinition.java
@@ -6,7 +6,7 @@ import nl.ramsolutions.sw.magik.analysis.typing.TypeString;
 /** A resolvable type definition. */
 public interface ITypeStringDefinition extends IDefinition {
 
-  public TypeString getTypeString();
+  TypeString getTypeString();
 
   // TODO: Parents.
 

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/magik/analysis/typing/ClassInfoDefinitionReaderTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/magik/analysis/typing/ClassInfoDefinitionReaderTest.java
@@ -45,10 +45,10 @@ class ClassInfoDefinitionReaderTest {
                 "class_definition_reader_test",
                 """
 
-            This is an example global
-            to be tested.
+                This is an example global
+                to be tested.
 
-            """,
+                """,
                 null,
                 doAnotherThingRef,
                 TypeString.UNDEFINED,
@@ -65,12 +65,12 @@ class ClassInfoDefinitionReaderTest {
                 null,
                 "class_definition_reader_test",
                 """
-            This will report. The
-            params are the things
-            that are going to be reported.
+                This will report. The
+                params are the things
+                that are going to be reported.
 
-            See also: !do_another_thing!
-            """,
+                See also: !do_another_thing!
+                """,
                 null,
                 reportRef,
                 TypeString.UNDEFINED,
@@ -125,9 +125,9 @@ class ClassInfoDefinitionReaderTest {
                 "class_definition_reader_test",
                 """
 
-            Example mixin for class_info.
+                Example mixin for class_info.
 
-            """,
+                """,
                 null,
                 ExemplarDefinition.Sort.MIXIN,
                 exampleMixinRef,
@@ -275,18 +275,18 @@ class ClassInfoDefinitionReaderTest {
                         "file:///$SMALLWORLD_GIS/sw_core/modules/sw_core/example_module/source/example_mixin.magik")),
                 null,
                 "class_definition_reader_test",
-"""
+                """
 
-This is a longer method doc
-to be tested.
-And then some more
-( things ).
+                This is a longer method doc
+                to be tested.
+                And then some more
+                ( things ).
 
-PARAM1 is a rope with
-{ value1, value2, value3, ... }
-for examples.
+                PARAM1 is a rope with
+                { value1, value2, value3, ... }
+                for examples.
 
-""",
+                """,
                 null,
                 exampleMixinRef,
                 "do_something_else()",

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/magik/analysis/typing/ClassInfoDefinitionReaderTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/magik/analysis/typing/ClassInfoDefinitionReaderTest.java
@@ -275,7 +275,7 @@ class ClassInfoDefinitionReaderTest {
                         "file:///$SMALLWORLD_GIS/sw_core/modules/sw_core/example_module/source/example_mixin.magik")),
                 null,
                 "class_definition_reader_test",
-                """
+"""
 
 This is a longer method doc
 to be tested.

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     <spotless.version>3.4.0</spotless.version>
-    <google-java-format.version>1.22.0</google-java-format.version>
-    <cleanthat.version>2.18</cleanthat.version>
+    <google-java-format.version>1.35.0</google-java-format.version>
+    <cleanthat.version>2.26</cleanthat.version>
     <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
     <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     <spotless.version>3.4.0</spotless.version>
-    <google-java-format.version>1.35.0</google-java-format.version>
+    <google-java-format.version>1.28.0</google-java-format.version>
     <cleanthat.version>2.26</cleanthat.version>
     <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
     <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>


### PR DESCRIPTION
Bump `cleanthat` and `google-java-format` versions manually, since Dependabot can't see them (they're only referenced from spotless-maven-plugin's own `<configuration>` block, not a real `<dependency>`/`<plugin>` position).

We couldn't upgrade to the latest version of `google-java-format` since 1.28.0 is the last version that supports Java 17.