### PR TITLE
Fix CLA Check by removing the unsafe fork checkout

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  contents: read
   pull-requests: write
   statuses: write
 
@@ -13,28 +14,26 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: head
-
-      - name: Checkout base branch
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.base_ref }}
-          path: base
-
       - name: Check CLA signature
         id: cla
         env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           echo "Checking CLA for user: $PR_AUTHOR"
 
+          fetch_signers() {
+            gh api "repos/${REPO}/contents/CLA-SIGNERS?ref=$1" \
+              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null
+          }
+
           signed=false
-          for dir in head base; do
-            if [ -f "$dir/CLA-SIGNERS" ] && grep -qiF "| ${PR_AUTHOR} |" "$dir/CLA-SIGNERS"; then
+          for ref in "$HEAD_SHA" "$BASE_REF"; do
+            content="$(fetch_signers "$ref")"
+            if [ -n "$content" ] && echo "$content" | grep -qiF "| ${PR_AUTHOR} |"; then
               signed=true
               break
             fi

--- a/changes/629.bugfix.md
+++ b/changes/629.bugfix.md
@@ -1,0 +1,1 @@
+Fix `CLA Check` failing for every contributor PR since `actions/checkout` was bumped to v7, by reading `CLA-SIGNERS` via the GitHub API instead of checking out fork PR code under `pull_request_target`.


### PR DESCRIPTION
## Summary
- `actions/checkout@v7` (bumped by #606) defaults `allow-unsafe-pr-checkout` to `false`, and refuses to check out a fork PR's head SHA under `pull_request_target` (the elevated-token/secrets context) — exactly what this workflow's "Checkout PR head" step was doing. That step has been failing outright on every human contributor's PR since the bump, skipping the actual CLA-signature check and always reporting the PR as unsigned, even for already-signed contributors.
- `pull_request_target` is required here (not `pull_request`) because the workflow needs to post a comment and set a commit status on fork PRs — `pull-requests: write`/`statuses: write` — which `pull_request` forces to read-only for fork PRs regardless of the `permissions:` block.
- Fix: replace both `actions/checkout` steps with GitHub Contents API reads of just `CLA-SIGNERS` (at the PR head SHA and the base ref), so nothing from the fork is ever checked out onto the runner — only one known file's bytes are read over the API, avoiding the checkout step's "trusted token + untrusted fork code on disk" pattern entirely. Added `contents: read` to `permissions:` (needed for the Contents API call; unlisted scopes default to `none` once a `permissions:` block is present).

**Note on the "CLA Check" status on this PR itself**: it will keep failing here, and that's expected, not a bug — `pull_request_target` always runs the workflow definition from the **base branch** (`develop`), not the PR's branch, precisely so a PR can't rewrite the check to fake a pass. This fix can only take effect for PRs opened *after* it's merged into `develop`.

## Test plan
- [x] YAML validated (`js-yaml` parse)
- [x] `gh api repos/.../contents/CLA-SIGNERS?ref=develop --jq '.content' | base64 -d` confirmed working against the live repo, returning the expected `CLA-SIGNERS` content
- [x] Grep logic confirmed against real signers: `sebastiaanspeck`/`StevenLooman` match, an unknown user doesn't
- [x] Confirmed *why* this PR's own "CLA Check" run still fails: its job log still shows the old "Checkout PR head" step, i.e. it ran the pre-fix workflow from `develop` — consistent with `pull_request_target`'s base-branch-workflow semantics, not a problem with the fix itself