### PR TITLE
Fix product/module naming check failing on `.`

### DIFF
--- a/changes/633.bugfix.md
+++ b/changes/633.bugfix.md
@@ -1,0 +1,4 @@
+Fix product/module naming check failing on `.`
+
+`ProductDefNameDoesNotMatchDirectoryName` and `ModuleDefNameDoesNotMatchDirectoryName`
+failed when scanning with a relative path such as `.`.

--- a/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/Utils.java
+++ b/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/Utils.java
@@ -49,7 +49,7 @@ final class Utils {
     try {
       final MagikToolsProperties fileProperties =
           ConfigurationReader.readProperties(path, properties);
-      final URI uri = path.toUri();
+      final URI uri = path.toAbsolutePath().normalize().toUri();
       final Charset charset = FileCharsetDeterminer.determineCharset(path);
       final String fileContents = Files.readString(path, charset);
 

--- a/magik-typed-lint/src/main/java/nl/ramsolutions/sw/magik/typedlint/MagikTypedLint.java
+++ b/magik-typed-lint/src/main/java/nl/ramsolutions/sw/magik/typedlint/MagikTypedLint.java
@@ -70,7 +70,7 @@ public class MagikTypedLint {
     try {
       final MagikToolsProperties fileProperties =
           ConfigurationReader.readProperties(path, this.properties);
-      final URI uri = path.toUri();
+      final URI uri = path.toAbsolutePath().normalize().toUri();
       final Charset charset = FileCharsetDeterminer.determineCharset(path);
       final String fileContents = Files.readString(path, charset);
       return new MagikTypedFile(fileProperties, uri, fileContents, this.definitionKeeper);

--- a/magik-typed-lint/src/main/java/nl/ramsolutions/sw/magik/typedlint/Main.java
+++ b/magik-typed-lint/src/main/java/nl/ramsolutions/sw/magik/typedlint/Main.java
@@ -250,6 +250,22 @@ public final class Main {
     }
   }
 
+  private static void populateDefinitionKeeper(
+      final CommandLine commandLine,
+      final MagikToolsProperties properties,
+      final IDefinitionKeeper definitionKeeper)
+      throws IOException {
+    if (commandLine.hasOption(OPTION_TYPE_DATABASE)) {
+      final String[] typeDatabasePaths = commandLine.getOptionValues(OPTION_TYPE_DATABASE);
+      Main.readTypeDatabases(typeDatabasePaths, definitionKeeper);
+    }
+
+    if (commandLine.hasOption(OPTION_PRE_INDEX_DIR)) {
+      final String[] indexDirs = commandLine.getOptionValues(OPTION_PRE_INDEX_DIR);
+      Main.indexPaths(indexDirs, properties, definitionKeeper);
+    }
+  }
+
   private static void indexPaths(
       final String[] indexDirs,
       final MagikToolsProperties properties,
@@ -258,7 +274,7 @@ public final class Main {
     final IgnoreHandler ignoreHandler = new IgnoreHandler();
     final MagikIndexer magikIndexer = new MagikIndexer(definitionKeeper, properties, ignoreHandler);
     for (final String indexDir : indexDirs) {
-      final Path path = Path.of(indexDir).toAbsolutePath();
+      final Path path = Path.of(indexDir).toAbsolutePath().normalize();
       final URI uri = path.toUri();
       final FileEvent fileEvent = new FileEvent(uri, FileEvent.FileChangeType.CREATED);
       magikIndexer.handleFileEvent(fileEvent);
@@ -352,17 +368,8 @@ public final class Main {
       System.exit(0);
     }
 
-    // Read type database(s).
-    if (commandLine.hasOption(OPTION_TYPE_DATABASE)) {
-      final String[] typeDatabasePaths = commandLine.getOptionValues(OPTION_TYPE_DATABASE);
-      Main.readTypeDatabases(typeDatabasePaths, definitionKeeper);
-    }
-
-    // Pre-index directory/directories.
-    if (commandLine.hasOption(OPTION_PRE_INDEX_DIR)) {
-      final String[] indexDirs = commandLine.getOptionValues(OPTION_PRE_INDEX_DIR);
-      Main.indexPaths(indexDirs, properties, definitionKeeper);
-    }
+    // Read type database(s) and pre-index directory/directories.
+    Main.populateDefinitionKeeper(commandLine, properties, definitionKeeper);
 
     // Index files from command line.
     final String[] leftOverArgs = commandLine.getArgs();


### PR DESCRIPTION
Fix product/module naming check failing on `.`. Fixes #613