### PR TITLE
Show the language server's own logging at the level it was logged with

### DIFF
--- a/changes/648.bugfix.md
+++ b/changes/648.bugfix.md
@@ -1,0 +1,6 @@
+Show the language server's own logging at the level it was logged with.
+
+Every line the language server wrote was shown as an error in the `Magik Language Server`
+output channel. Its `SEVERE`, `WARNING` and `INFO` lines are now logged as such. The finer
+levels are logged as information, rather than as debug or trace, so that they stay visible
+at the default log level of the output channel.

--- a/magik-language-server/client-vscode/client/src/language-client.ts
+++ b/magik-language-server/client-vscode/client/src/language-client.ts
@@ -5,6 +5,7 @@ import * as vscodeLanguageClient from 'vscode-languageclient/node';
 
 import { getJavaExec } from './common';
 import { MAGIK_TOOLS_VERSION } from './const';
+import { createServerLogOutputChannel } from './logging';
 import { MagikSessionProvider } from './magik-session';
 
 
@@ -29,7 +30,7 @@ export class MagikLanguageClient implements vscode.Disposable {
 			this._outputSessionCounter === 1
 				? 'Magik Language Server'
 				: `Magik Language Server #${this._outputSessionCounter}`;
-		const outputChannel = vscode.window.createOutputChannel(channelName, { log: true });
+		const outputChannel = createServerLogOutputChannel(channelName);
 		this._context.subscriptions.push(outputChannel);
 		return outputChannel;
 	}

--- a/magik-language-server/client-vscode/client/src/logging.ts
+++ b/magik-language-server/client-vscode/client/src/logging.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 
+import { ServerLogLevel, readServerLogLevel } from './server-log';
+
 let logger: vscode.LogOutputChannel | undefined;
 
 /**
@@ -23,4 +25,117 @@ export function registerLogger(context: vscode.ExtensionContext): vscode.LogOutp
 	const log = getLogger();
 	context.subscriptions.push(log);
 	return log;
+}
+
+/**
+ * Log output channel that logs the language server's own `SEVERE` and `WARNING`
+ * lines as such, instead of logging everything the server writes as an error.
+ */
+class ServerLogOutputChannel implements vscode.LogOutputChannel {
+	private readonly _channel: vscode.LogOutputChannel;
+
+	constructor(channel: vscode.LogOutputChannel) {
+		this._channel = channel;
+	}
+
+	public get name(): string {
+		return this._channel.name;
+	}
+
+	public get logLevel(): vscode.LogLevel {
+		return this._channel.logLevel;
+	}
+
+	public get onDidChangeLogLevel(): vscode.Event<vscode.LogLevel> {
+		return this._channel.onDidChangeLogLevel;
+	}
+
+	public append(value: string): void {
+		this._channel.append(value);
+	}
+
+	public appendLine(value: string): void {
+		this._channel.appendLine(value);
+	}
+
+	public replace(value: string): void {
+		this._channel.replace(value);
+	}
+
+	public clear(): void {
+		this._channel.clear();
+	}
+
+	public show(column?: vscode.ViewColumn | boolean, preserveFocus?: boolean): void {
+		// The column is ignored by VSCode for output channels, hence the
+		// deprecated overload taking one is not forwarded.
+		this._channel.show(typeof column === 'boolean' ? column : preserveFocus);
+	}
+
+	public hide(): void {
+		this._channel.hide();
+	}
+
+	public dispose(): void {
+		this._channel.dispose();
+	}
+
+	public trace(message: string, ...args: unknown[]): void {
+		this._channel.trace(message, ...args);
+	}
+
+	public debug(message: string, ...args: unknown[]): void {
+		this._channel.debug(message, ...args);
+	}
+
+	public info(message: string, ...args: unknown[]): void {
+		this._channel.info(message, ...args);
+	}
+
+	public warn(message: string, ...args: unknown[]): void {
+		this._channel.warn(message, ...args);
+	}
+
+	public error(error: string | Error, ...args: unknown[]): void {
+		if (typeof error === 'string') {
+			const level = readServerLogLevel(error);
+			if (level !== undefined) {
+				this.logWithLevel(level, error, ...args);
+				return;
+			}
+		}
+
+		this._channel.error(error, ...args);
+	}
+
+	private logWithLevel(level: ServerLogLevel, message: string, ...args: unknown[]): void {
+		switch (level) {
+			case 'SEVERE':
+				this._channel.error(message, ...args);
+				break;
+			case 'WARNING':
+				this._channel.warn(message, ...args);
+				break;
+			// The finer levels are logged as information, and not as debug or trace, to
+			// keep them visible at the default log level of a channel.
+			case 'INFO':
+			case 'CONFIG':
+			case 'FINE':
+			case 'FINER':
+			case 'FINEST':
+			default:
+				this._channel.info(message, ...args);
+				break;
+		}
+	}
+}
+
+/**
+ * Create a log output channel for a language server session.
+ * @param name Name of the channel.
+ * @returns The log output channel.
+ */
+export function createServerLogOutputChannel(name: string): vscode.LogOutputChannel {
+	const channel = vscode.window.createOutputChannel(name, { log: true });
+	return new ServerLogOutputChannel(channel);
 }

--- a/magik-language-server/client-vscode/client/src/server-log.test.ts
+++ b/magik-language-server/client-vscode/client/src/server-log.test.ts
@@ -1,0 +1,49 @@
+import * as assert from 'node:assert';
+
+import { readServerLogLevel } from './server-log';
+
+describe('readServerLogLevel', () => {
+	it('reads the level from a log line', () => {
+		const line =
+			'2026-07-28 11:20:47 FINE    nl.ramsolutions.sw.magik.languageserver.MagikTextDocumentService : didOpen, uri: file:///a.magik ';
+		assert.strictEqual(readServerLogLevel(line), 'FINE');
+	});
+
+	it('reads a level that is not padded', () => {
+		const line =
+			'2026-07-28 11:20:47 WARNING nl.ramsolutions.sw.magik.languageserver.MagikLanguageServer : Something ';
+		assert.strictEqual(readServerLogLevel(line), 'WARNING');
+	});
+
+	it('reads every level the server logs with', () => {
+		const levels = ['SEVERE', 'WARNING', 'INFO', 'CONFIG', 'FINE', 'FINER', 'FINEST'];
+		for (const level of levels) {
+			const line = `2026-07-28 11:20:47 ${level.padEnd(7)} some.Logger : message `;
+			assert.strictEqual(readServerLogLevel(line), level);
+		}
+	});
+
+	it('ignores a line without a timestamp', () => {
+		assert.strictEqual(readServerLogLevel('FINE some.Logger : message'), undefined);
+	});
+
+	it('ignores the non-debug log format, which carries no level', () => {
+		assert.strictEqual(readServerLogLevel('PID: 284683'), undefined);
+		assert.strictEqual(readServerLogLevel('Version: 0.13.0-SNAPSHOT'), undefined);
+	});
+
+	it('ignores an unknown level', () => {
+		assert.strictEqual(readServerLogLevel('2026-07-28 11:20:47 TRACE   some.Logger : message'), undefined);
+	});
+
+	it('ignores a stack trace continuation line', () => {
+		assert.strictEqual(readServerLogLevel('\tat java.base/java.lang.Thread.run(Thread.java:1583)'), undefined);
+	});
+
+	it('ignores a level that is not at the start of the line', () => {
+		assert.strictEqual(
+			readServerLogLevel('prefix 2026-07-28 11:20:47 FINE    some.Logger : message'),
+			undefined
+		);
+	});
+});

--- a/magik-language-server/client-vscode/client/src/server-log.ts
+++ b/magik-language-server/client-vscode/client/src/server-log.ts
@@ -1,0 +1,34 @@
+/**
+ * Levels the Magik language server logs with, as written by `java.util.logging`.
+ */
+export type ServerLogLevel =
+	| 'SEVERE'
+	| 'WARNING'
+	| 'INFO'
+	| 'CONFIG'
+	| 'FINE'
+	| 'FINER'
+	| 'FINEST';
+
+/**
+ * Pattern for a log line as written by the language server when started with
+ * `--debug`. Kept in sync with `java.util.logging.SimpleFormatter.format` in
+ * `magik-language-server/src/main/resources/debug-logging.properties`:
+ * `%1$tF %1$tT %4$-7s %3$s : %5$s %6$s%n`.
+ */
+const SERVER_LOG_LINE =
+	/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} +(SEVERE|WARNING|INFO|CONFIG|FINE|FINER|FINEST) /;
+
+/**
+ * Read the level a language server log line was logged with.
+ * @param line Line as written by the language server to stderr.
+ * @returns The level, or `undefined` when the line is not a formatted log line.
+ */
+export function readServerLogLevel(line: string): ServerLogLevel | undefined {
+	const match = SERVER_LOG_LINE.exec(line);
+	if (match === null) {
+		return undefined;
+	}
+
+	return match[1] as ServerLogLevel;
+}


### PR DESCRIPTION
Show the language server's own logging at the level it was logged with