### PR TITLE
Include the `load_list` checks in magik-lint's `--show-checks` output

### DIFF
--- a/changes/651.bugfix.md
+++ b/changes/651.bugfix.md
@@ -1,0 +1,1 @@
+Include the `load_list` checks in magik-lint's `--show-checks` output.

--- a/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/MagikLint.java
+++ b/magik-lint/src/main/java/nl/ramsolutions/sw/magik/lint/MagikLint.java
@@ -17,6 +17,7 @@ import nl.ramsolutions.sw.checks.CheckMetadata;
 import nl.ramsolutions.sw.checks.ChecksConfiguration;
 import nl.ramsolutions.sw.checks.Issue;
 import nl.ramsolutions.sw.checks.IssueDisabledChecker;
+import nl.ramsolutions.sw.checks.LoadListCheckList;
 import nl.ramsolutions.sw.checks.MagikCheckList;
 import nl.ramsolutions.sw.checks.ModuleDefCheckList;
 import nl.ramsolutions.sw.checks.ProductDefCheckList;
@@ -185,6 +186,7 @@ public class MagikLint {
     return Stream.of(
             ProductDefCheckList.INSTANCE.getBaseChecks().stream(),
             ModuleDefCheckList.INSTANCE.getBaseChecks().stream(),
+            LoadListCheckList.INSTANCE.getBaseChecks().stream(),
             MagikCheckList.INSTANCE.getBaseChecks().stream())
         .flatMap(stream -> stream)
         .sorted(Comparator.comparing(Class::getSimpleName))


### PR DESCRIPTION
Include the `load_list` checks in magik-lint's `--show-checks` output.

Fixes #646