### PR TITLE
Add the setting `magik.sourcePathMappings` to rewrite recorded source-path prefixes

### DIFF
--- a/changes/655.feature.md
+++ b/changes/655.feature.md
@@ -1,0 +1,7 @@
+Add the setting `magik.sourcePathMappings` to rewrite recorded source-path prefixes.
+
+Definitions read from class-info can record a source path which does not exist on this host, such as
+an absolute path from the machine the library was built on. The new setting maps such a prefix -- an
+absolute path or a logical -- to a local path or to another logical, with the longest matching prefix
+winning. The replacement is expanded afterwards, so a mapping can chain into `$SMALLWORLD_GIS` or
+another logical.

--- a/magik-language-server/client-vscode/package.json
+++ b/magik-language-server/client-vscode/package.json
@@ -308,6 +308,13 @@
           "description": "Path to Smallworld Core -- only used by the VS Code extension.",
           "type": "string"
         },
+        "magik.sourcePathMappings": {
+          "description": "Rewrite recorded source-path prefixes so library definitions resolve on this host. Maps a prefix -- a logical (e.g. \"$SOMS_DIR\") or an absolute path (e.g. \"C:/projects/hg/gma\") -- to a local path or another logical, which is expanded in turn. The longest matching prefix wins.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "magik.javaHome": {
           "description": "Path to Java Runtime, Java 17 minimum -- only used by the VS Code extension.",
           "type": "string"

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/ClientLocationResolver.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/ClientLocationResolver.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import nl.ramsolutions.sw.magik.Location;
 import nl.ramsolutions.sw.magik.SourcePathResolver;
@@ -27,19 +26,17 @@ public final class ClientLocationResolver {
    * Resolve and dedup locations for the client.
    *
    * @param locations The locations to prepare.
-   * @param environment Environment-variable resolver (e.g. {@code magik.smallworldGis} overlaid on
-   *     the process environment).
+   * @param sourcePathResolver Configured source-path resolver (env-variable expansion + prefix
+   *     rewrites).
    * @return Resolved, deduped locations in first-seen order.
    */
   public static List<Location> resolveAndDedup(
-      final List<Location> locations, final Function<String, String> environment) {
+      final List<Location> locations, final SourcePathResolver sourcePathResolver) {
     final List<Location> resolved =
         locations.stream()
             .map(
                 location ->
-                    new Location(
-                        SourcePathResolver.expand(location.getUri(), environment),
-                        location.getRange()))
+                    new Location(sourcePathResolver.expand(location.getUri()), location.getRange()))
             .toList();
 
     final Set<URI> urisWithRange =

--- a/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikTextDocumentService.java
+++ b/magik-language-server/src/main/java/nl/ramsolutions/sw/magik/languageserver/MagikTextDocumentService.java
@@ -10,12 +10,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import nl.ramsolutions.sw.ConfigurationReader;
 import nl.ramsolutions.sw.MagikToolsProperties;
 import nl.ramsolutions.sw.OpenedFile;
 import nl.ramsolutions.sw.loadlist.LoadListFile;
 import nl.ramsolutions.sw.magik.MagikTypedFile;
+import nl.ramsolutions.sw.magik.SourcePathResolver;
 import nl.ramsolutions.sw.magik.analysis.MagikAnalysisSettings;
 import nl.ramsolutions.sw.magik.analysis.definitions.IDefinitionKeeper;
 import nl.ramsolutions.sw.magik.languageserver.callhierarchy.CallHierarchyProvider;
@@ -1623,9 +1623,9 @@ public class MagikTextDocumentService implements TextDocumentService {
 
   private List<Location> toClientLocations(
       final List<nl.ramsolutions.sw.magik.Location> locations) {
-    final Function<String, String> environment =
-        new MagikAnalysisSettings(this.properties).getEnvironment();
-    return ClientLocationResolver.resolveAndDedup(locations, environment).stream()
+    final SourcePathResolver sourcePathResolver =
+        new MagikAnalysisSettings(this.properties).getSourcePathResolver();
+    return ClientLocationResolver.resolveAndDedup(locations, sourcePathResolver).stream()
         .map(Lsp4jConversion::locationToLsp4j)
         .toList();
   }

--- a/magik-language-server/src/test/java/nl/ramsolutions/sw/magik/languageserver/ClientLocationResolverTest.java
+++ b/magik-language-server/src/test/java/nl/ramsolutions/sw/magik/languageserver/ClientLocationResolverTest.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 import nl.ramsolutions.sw.magik.Location;
 import nl.ramsolutions.sw.magik.Position;
 import nl.ramsolutions.sw.magik.Range;
+import nl.ramsolutions.sw.magik.SourcePathResolver;
 import org.junit.jupiter.api.Test;
 
 class ClientLocationResolverTest {
@@ -26,7 +27,8 @@ class ClientLocationResolverTest {
         new Location(concreteUri, new Range(new Position(3, 0), new Position(3, 5)));
 
     final List<Location> result =
-        ClientLocationResolver.resolveAndDedup(List.of(classInfo, indexed), env);
+        ClientLocationResolver.resolveAndDedup(
+            List.of(classInfo, indexed), new SourcePathResolver(env, Map.of()));
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getUri()).isEqualTo(concreteUri);
@@ -39,7 +41,9 @@ class ClientLocationResolverTest {
     final Location a = new Location(URI.create("file:///proj/a.magik"));
     final Location b = new Location(URI.create("file:///proj/b.magik"));
 
-    final List<Location> result = ClientLocationResolver.resolveAndDedup(List.of(a, b), env);
+    final List<Location> result =
+        ClientLocationResolver.resolveAndDedup(
+            List.of(a, b), new SourcePathResolver(env, Map.of()));
 
     assertThat(result).hasSize(2);
   }
@@ -52,7 +56,9 @@ class ClientLocationResolverTest {
     final Location hit1 = new Location(uri, new Range(new Position(1, 0), new Position(1, 3)));
     final Location hit2 = new Location(uri, new Range(new Position(7, 0), new Position(7, 3)));
 
-    final List<Location> result = ClientLocationResolver.resolveAndDedup(List.of(hit1, hit2), env);
+    final List<Location> result =
+        ClientLocationResolver.resolveAndDedup(
+            List.of(hit1, hit2), new SourcePathResolver(env, Map.of()));
 
     assertThat(result).containsExactly(hit1, hit2);
   }

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/MagikToolsProperties.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/MagikToolsProperties.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -301,6 +302,26 @@ public class MagikToolsProperties {
 
     final String[] values = value.split(MagikToolsProperties.LIST_SEPARATOR);
     return Arrays.stream(values).map(String::trim).toList();
+  }
+
+  /**
+   * Get the properties under a key prefix as a map. A nested settings object ({@code prefix: {a: x,
+   * b: y}}) is flattened by the client converter to keys {@code prefix.a}/{@code prefix.b}; this
+   * reads them back as a map ({@code {a: x, b: y}}).
+   *
+   * @param prefix Key prefix (without trailing dot).
+   * @return Map of sub-key to value.
+   */
+  public Map<String, String> getPropertyMap(final String prefix) {
+    final String dottedPrefix = prefix + ".";
+    final Map<String, String> result = new HashMap<>();
+    for (final String name : this.properties.stringPropertyNames()) {
+      if (name.startsWith(dottedPrefix)) {
+        result.put(name.substring(dottedPrefix.length()), this.properties.getProperty(name));
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/SourcePathResolver.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/SourcePathResolver.java
@@ -2,6 +2,7 @@ package nl.ramsolutions.sw.magik;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -20,7 +21,31 @@ public final class SourcePathResolver {
   // the raw "/C:/..." (or "/C:\\...") must lose its leading slash to be a valid OS path.
   private static final Pattern ROOTED_WINDOWS_DRIVE = Pattern.compile("^/([A-Za-z]:[\\\\/].*)$");
 
-  private SourcePathResolver() {}
+  private final Function<String, String> environment;
+  private final Map<String, String> prefixMappings;
+
+  /**
+   * Constructor for a configured resolver that owns its environment and prefix mappings, so callers
+   * hold a single mapper rather than threading resolution config.
+   *
+   * @param environment Resolver mapping a variable name to its value (or {@code null} if unset).
+   * @param prefixMappings Path-prefix rewrites (recorded prefix to replacement).
+   */
+  public SourcePathResolver(
+      final Function<String, String> environment, final Map<String, String> prefixMappings) {
+    this.environment = environment;
+    this.prefixMappings = prefixMappings;
+  }
+
+  /**
+   * Resolve a URI using this resolver's environment and prefix mappings.
+   *
+   * @param uri The (possibly placeholder-containing) file URI.
+   * @return The resolved URI, or {@code uri} unchanged when there is nothing to rewrite or expand.
+   */
+  public URI expand(final URI uri) {
+    return SourcePathResolver.expand(uri, this.environment, this.prefixMappings);
+  }
 
   /**
    * Expand {@code $NAME} occurrences in the URI's path from the given resolver.
@@ -30,19 +55,66 @@ public final class SourcePathResolver {
    * @return The expanded URI, or {@code uri} unchanged when there is nothing to expand.
    */
   public static URI expand(final URI uri, final Function<String, String> environment) {
+    return SourcePathResolver.expand(uri, environment, Map.of());
+  }
+
+  /**
+   * Rewrite the URI's path by a configured prefix mapping, then expand {@code $NAME} occurrences.
+   *
+   * <p>Prefix mappings rewrite a raw, installation-specific absolute path (e.g. a {@code
+   * C:/projects/...} path baked into class-info by a Windows build) into a local path or a logical
+   * ({@code $NAME}), the longest matching prefix winning. Any resulting {@code $NAME} is then
+   * expanded from {@code environment}, so a mapping may chain into a logical.
+   *
+   * @param uri The (possibly placeholder-containing) file URI.
+   * @param environment Resolver mapping a variable name to its value (or {@code null} if unset).
+   * @param prefixMappings Path-prefix rewrites (recorded prefix to replacement).
+   * @return The resolved URI, or {@code uri} unchanged when there is nothing to rewrite or expand.
+   */
+  public static URI expand(
+      final URI uri,
+      final Function<String, String> environment,
+      final Map<String, String> prefixMappings) {
     final String path = uri.getPath();
     if (path == null) {
       return uri;
     }
 
-    final String expanded = SourcePathResolver.expandVariables(path, environment);
+    final String rewritten = SourcePathResolver.applyPrefixMappings(path, prefixMappings);
+    final String expanded = SourcePathResolver.expandVariables(rewritten, environment);
     if (expanded.equals(path)) {
-      // Nothing expanded: return the original URI so Path.of(uri) stays correct across platforms
+      // Nothing changed: return the original URI so Path.of(uri) stays correct across platforms
       // (a file URI's raw path -- e.g. "/C:/..." on Windows -- is not itself a valid OS path).
       return uri;
     }
 
     return SourcePathResolver.toOsPath(expanded).toUri();
+  }
+
+  /**
+   * Replace the longest matching prefix in {@code path}. A file URI's path is rooted ({@code
+   * "/..."}); a configured prefix may or may not include that leading slash, so both forms are
+   * tried.
+   */
+  private static String applyPrefixMappings(
+      final String path, final Map<String, String> prefixMappings) {
+    String matchedPrefix = null;
+    String replacement = null;
+    for (final Map.Entry<String, String> entry : prefixMappings.entrySet()) {
+      for (final String candidate : new String[] {entry.getKey(), "/" + entry.getKey()}) {
+        if (path.startsWith(candidate)
+            && (matchedPrefix == null || candidate.length() > matchedPrefix.length())) {
+          matchedPrefix = candidate;
+          replacement = entry.getValue();
+        }
+      }
+    }
+
+    if (matchedPrefix == null) {
+      return path;
+    }
+
+    return replacement + path.substring(matchedPrefix.length());
   }
 
   private static Path toOsPath(final String expandedUriPath) {

--- a/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/MagikAnalysisSettings.java
+++ b/magik-squid/src/main/java/nl/ramsolutions/sw/magik/analysis/MagikAnalysisSettings.java
@@ -1,7 +1,9 @@
 package nl.ramsolutions.sw.magik.analysis;
 
+import java.util.Map;
 import java.util.function.Function;
 import nl.ramsolutions.sw.MagikToolsProperties;
+import nl.ramsolutions.sw.magik.SourcePathResolver;
 
 /**
  * Settings for magik analysis.
@@ -20,6 +22,7 @@ public class MagikAnalysisSettings {
       "magik.typing.indexBinaryOperatorUsages";
   private static final String CACHE_INDEXED_DEFINITIONS = "magik.typing.cacheIndexedDefinitions";
   private static final String SMALLWORLD_GIS = "magik.smallworldGis";
+  private static final String SOURCE_PATH_MAPPINGS = "magik.sourcePathMappings";
 
   /**
    * Name of the Smallworld logical, as it appears in dumped source paths ({@code $SMALLWORLD_GIS}).
@@ -108,6 +111,28 @@ public class MagikAnalysisSettings {
    */
   public String getSmallworldGis() {
     return this.properties.getPropertyString(SMALLWORLD_GIS);
+  }
+
+  /**
+   * Get the configured source-path prefix mappings, used to rewrite a raw, installation-specific
+   * absolute source path (e.g. a {@code C:/projects/...} path baked into class-info) or a logical
+   * ({@code $SOMS_DIR}) to a resolvable path. Configured as an object {@code
+   * magik.sourcePathMappings: { "<from>": "<to>" }}.
+   *
+   * @return Map of recorded path prefix to replacement.
+   */
+  public Map<String, String> getSourcePathMappings() {
+    return this.properties.getPropertyMap(SOURCE_PATH_MAPPINGS);
+  }
+
+  /**
+   * Build a configured source-path resolver that owns the environment resolver and the prefix
+   * mappings, so consumers hold a single mapper rather than threading resolution config.
+   *
+   * @return The source-path resolver.
+   */
+  public SourcePathResolver getSourcePathResolver() {
+    return new SourcePathResolver(this.getEnvironment(), this.getSourcePathMappings());
   }
 
   /**

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/magik/SourcePathResolverTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/magik/SourcePathResolverTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
+/** Tests for {@link SourcePathResolver}. */
 class SourcePathResolverTest {
 
   @Test
@@ -19,7 +20,6 @@ class SourcePathResolverTest {
 
   @Test
   void testVariableIsExpandedToRealPathOnAnyOs() {
-    // Use a real OS path as the logical's value so the assertion holds on POSIX and Windows alike.
     final Path gisRoot = Path.of(System.getProperty("java.io.tmpdir"), "sw530");
     final Function<String, String> env = Map.of("SMALLWORLD_GIS", gisRoot.toString())::get;
     final URI uri = URI.create("file:///$SMALLWORLD_GIS/sw_core/foo.magik");
@@ -33,5 +33,47 @@ class SourcePathResolverTest {
   void testUnresolvedVariableIsLeftLiteral() {
     final URI uri = URI.create("file:///$NOT_SET/foo.magik");
     assertThat(SourcePathResolver.expand(uri, name -> null)).isEqualTo(uri);
+  }
+
+  @Test
+  void testPrefixMappingRewritesRawAbsolutePath() {
+    final Path localRoot = Path.of(System.getProperty("java.io.tmpdir"), "gma");
+    final URI uri = URI.create("file:///C:/projects/hg/gma/foo.magik");
+    final Map<String, String> mappings = Map.of("C:/projects/hg/gma", localRoot.toString());
+
+    final URI expanded = SourcePathResolver.expand(uri, name -> null, mappings);
+
+    assertThat(Path.of(expanded)).isEqualTo(localRoot.resolve("foo.magik"));
+  }
+
+  @Test
+  void testPrefixMappingChainsIntoVariableExpansion() {
+    final Path gisRoot = Path.of(System.getProperty("java.io.tmpdir"), "sw530");
+    final URI uri = URI.create("file:///C:/projects/hg/gma/foo.magik");
+    final Map<String, String> mappings = Map.of("C:/projects/hg/gma", "$SMALLWORLD_GIS/gma");
+    final Function<String, String> env = Map.of("SMALLWORLD_GIS", gisRoot.toString())::get;
+
+    final URI expanded = SourcePathResolver.expand(uri, env, mappings);
+
+    assertThat(Path.of(expanded)).isEqualTo(gisRoot.resolve("gma").resolve("foo.magik"));
+  }
+
+  @Test
+  void testLongestPrefixMappingWins() {
+    final Path a = Path.of(System.getProperty("java.io.tmpdir"), "a");
+    final Path b = Path.of(System.getProperty("java.io.tmpdir"), "b");
+    final URI uri = URI.create("file:///C:/projects/hg/gma/foo.magik");
+    final Map<String, String> mappings =
+        Map.of("C:/projects", a.toString(), "C:/projects/hg/gma", b.toString());
+
+    final URI expanded = SourcePathResolver.expand(uri, name -> null, mappings);
+
+    assertThat(Path.of(expanded)).isEqualTo(b.resolve("foo.magik"));
+  }
+
+  @Test
+  void testNoPrefixMappingLeavesUriUnchanged() {
+    final URI uri = URI.create("file:///home/me/proj/foo.magik");
+    assertThat(SourcePathResolver.expand(uri, name -> null, Map.of())).isEqualTo(uri);
   }
 }

--- a/magik-squid/src/test/java/nl/ramsolutions/sw/magik/analysis/MagikAnalysisSettingsTest.java
+++ b/magik-squid/src/test/java/nl/ramsolutions/sw/magik/analysis/MagikAnalysisSettingsTest.java
@@ -1,0 +1,36 @@
+package nl.ramsolutions.sw.magik.analysis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import nl.ramsolutions.sw.MagikToolsProperties;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link MagikAnalysisSettings}. */
+class MagikAnalysisSettingsTest {
+
+  @Test
+  void testSourcePathMappingsReadsFlattenedObject() {
+    // The client sends `magik.sourcePathMappings` as an object; the converter flattens it to
+    // `magik.sourcePathMappings.<from>` = `<to>`.
+    final MagikToolsProperties properties =
+        new MagikToolsProperties(
+            Map.of(
+                "magik.sourcePathMappings.$SOMS_DIR", "/opt/soms",
+                "magik.sourcePathMappings.C:/projects/hg/gma", "$SMALLWORLD_GIS/gma"));
+
+    final Map<String, String> mappings =
+        new MagikAnalysisSettings(properties).getSourcePathMappings();
+
+    assertThat(mappings)
+        .containsOnly(
+            Map.entry("$SOMS_DIR", "/opt/soms"),
+            Map.entry("C:/projects/hg/gma", "$SMALLWORLD_GIS/gma"));
+  }
+
+  @Test
+  void testSourcePathMappingsEmptyWhenUnset() {
+    final MagikToolsProperties properties = new MagikToolsProperties(Map.of());
+    assertThat(new MagikAnalysisSettings(properties).getSourcePathMappings()).isEmpty();
+  }
+}


### PR DESCRIPTION
Add the setting `magik.sourcePathMappings` to rewrite recorded source-path prefixes